### PR TITLE
Fixed misspelled variable '$ReferenceUserGroups'

### DIFF
--- a/Get-ADGroupsDifference.ps1
+++ b/Get-ADGroupsDifference.ps1
@@ -152,7 +152,7 @@ Function Get-ADGroupsDifference {
 
             if ($null -eq $ReferenceUserGroups) {
 
-                $ReferrenceUserGroups = @()
+                $ReferenceUserGroups = @()
 
             }
             elseif ($null -eq $CurrentUserGroups) {


### PR DESCRIPTION
The $ReferenceUserGroups variable was spelled with an extra 'r' - I corrected this.